### PR TITLE
add react-quill-new using quill 2.0.3

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,6 +32,7 @@
         "react-daisyui": "^5.0.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1",
+        "react-quill-new": "^3.3.3",
         "react-router-dom": "^6.21.2",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7"
@@ -4883,8 +4884,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -5692,6 +5692,20 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
       "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
+    "node_modules/react-quill-new": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.3.3.tgz",
+      "integrity": "sha512-jxbm1QUJlkuGUpc9/GUgGw5USLHdp43H0M7AufqS3V+zRLng9uqLeVBGjXYqEbUKi8QVOM4SClSV3F7kVNj68w==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "quill": "~2.0.2"
+      },
+      "peerDependencies": {
+        "quill-delta": "^5.1.0",
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "react-daisyui": "^5.0.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
+    "react-quill-new": "^3.3.3",
     "react-router-dom": "^6.21.2",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7"

--- a/client/src/pages/Dashboard/CourseEditor/index.tsx
+++ b/client/src/pages/Dashboard/CourseEditor/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { useContext, useEffect, useState } from 'react';
 import { CoursesContext } from '../../../context/CoursesContext';
-import ReactQuill from 'react-quill';
-import 'react-quill/dist/quill.snow.css';
+import ReactQuill from 'react-quill-new';
+import 'react-quill-new/dist/quill.snow.css';
 import parse from 'html-react-parser';
 import { Button } from '@/components/ui/button';
 
@@ -79,15 +79,16 @@ const CourseEditor = () => {
     e.preventDefault();
     setLoading(true);
     const newCourse = {
-      id: "99",
+      id: '99',
       title: courseTitle,
-      description: "a",
-      tutor: "Jay",
-      image: "https://jaydatamusic.com/wp-content/uploads/2016/03/jay-data-674fm-copy.jpg",
+      description: 'a',
+      tutor: 'Jay',
+      image:
+        'https://jaydatamusic.com/wp-content/uploads/2016/03/jay-data-674fm-copy.jpg',
       year: 2025,
-      category: "",
-      duration: "5:30",
-      price: "11.99",
+      category: '',
+      duration: '5:30',
+      price: '11.99',
       rating: 5,
       courseModules: [],
     };
@@ -219,7 +220,7 @@ const CourseEditor = () => {
     toolbar: [
       [{ header: [1, 2, false] }],
       ['bold', 'italic', 'underline', 'strike', 'blockquote'],
-      [{ list: 'ordered' }, { list: 'bullet' }],
+      [{ list: 'ordered' }],
       ['link', 'color', 'image'],
       [{ 'code-block': true }],
       ['clean'],
@@ -234,7 +235,6 @@ const CourseEditor = () => {
     'strike',
     'blockquote',
     'list',
-    'bullet',
     'link',
     'indent',
     'image',
@@ -330,7 +330,7 @@ const CourseEditor = () => {
           <h2 className="text-3xl font-bold border-b border-gray-400 pb-2 mb-5 ">
             Editor
           </h2>
-          <form>
+          <div>
             <div className="grid gap-4 sm:grid-cols-1 sm:gap-6">
               {/* Course */}
               <div className="p-3 border b-2 rounded-lg">
@@ -482,7 +482,6 @@ const CourseEditor = () => {
                   >
                     Lesson content
                   </label>
-                  {/* @ts-ignore */}
                   <ReactQuill
                     theme="snow"
                     value={lessonContent}
@@ -520,7 +519,7 @@ const CourseEditor = () => {
                 </div>
               </div>
             </div>
-          </form>
+          </div>
         </div>
 
         {/* {loading ? 'saving' : ''} */}


### PR DESCRIPTION
React-quill 2 used quill 1.3.7 and used a deprecated browser tag. That's why I had to swap it for react-quill-new.